### PR TITLE
build and install allolib and gamma

### DIFF
--- a/Formula/Gamma.rb
+++ b/Formula/Gamma.rb
@@ -12,7 +12,7 @@ class Gamma < Formula
     system "make", "Gamma"
 
     lib.install Dir["build/lib/libGamma.a"]
-    include.install Dir["build/include/Gamma"]
+    include.install Dir["Gamma"]
 
     test do
     end
@@ -20,6 +20,6 @@ class Gamma < Formula
 
   def uninstall
     lib.uninstall Dir["build/lib/libGamma.a"]
-    include.install Dir["build/include/Gamma"]
+    include.uninstall Dir["Gamma"]
   end
 end

--- a/Formula/Gamma.rb
+++ b/Formula/Gamma.rb
@@ -1,0 +1,25 @@
+class Gamma < Formula
+  desc "AlloSystem for OpenGL 3.3 or higher"
+  homepage "https://github.com/AlloSphere-Research-Group/Gamma"
+  head "https://github.com/AlloSphere-Research-Group/Gamma.git"
+
+  depends_on "cmake" => :build
+  depends_on "libsndfile"
+  depends_on "portaudio"
+
+  def install
+    system "cmake", ".", "-DNO_EXAMPLES=1", *std_cmake_args
+    system "make", "Gamma"
+
+    lib.install Dir["build/lib/libGamma.a"]
+    include.install Dir["build/include/Gamma"]
+
+    test do
+    end
+  end
+
+  def uninstall
+    lib.uninstall Dir["build/lib/libGamma.a"]
+    include.install Dir["build/include/Gamma"]
+  end
+end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -13,7 +13,7 @@ class Allolib < Formula
 
   def install
     mkdir "build" do
-    system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
+    system "cmake", "..", "-DNO_EXAMPLES=1", "-DCMAKE_INSTALL_PREFIX=#{prefix}", *std_cmake_args
     system "make", "al"
     system "make", "install"
     end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -14,7 +14,7 @@ class Allolib < Formula
   depends_on "rt-audio"
   depends_on "rtmidi"
   depends_on "portaudio"
-  depends_on "fftw3"
+  depends_on "fftw"
 
   def install
     mkdir "build" do

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -12,8 +12,6 @@ class Allolib < Formula
   depends_on 'libsndfile'
 
   def install
-    system "git submodule init"
-    system "git submodule update"
     mkdir "build" do
       system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
       system "make al"

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Allolib < Formula
-  head 'https://github.com/AlloSphere-Research-Group/allolib', :branch => "devel"
+  head 'https://github.com/akshay1992/allolib', :branch => "devel"
 
   depends_on 'cmake' => :build
   depends_on 'assimp'

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,7 +1,7 @@
 class Allolib < Formula
   desc "AlloSystem for OpenGL 3.3 or higher"
   homepage "https://github.com/AlloSphere-Research-Group/allolib"
-  head "https://github.com/akshay1992/allolib", :revision => "afa8e92203cda2c110d724b401cdfd9b6387204e"
+  head "https://github.com/akshay1992/allolib.git"
 
   depends_on "cmake" => :build
   depends_on "assimp"

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Allolib < Formula
-  head 'https://github.com/akshay1992/allolib', :revision => "afa8e92203cda2c110d724b401cdfd9b6387204e"
+  url 'https://github.com/akshay1992/allolib'
 
   depends_on 'cmake' => :build
   depends_on 'assimp'

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,9 +1,10 @@
 class Allolib < Formula
   desc "AlloSystem for OpenGL 3.3 or higher"
   homepage "https://github.com/AlloSphere-Research-Group/allolib"
-  head "https://github.com/akshay1992/allolib.git"
+  head "https://github.com/AlloSphere-Research-Group/allolib.git"
 
   depends_on "cmake" => :build
+  depends_on "apr"
   depends_on "Gamma"
   depends_on "assimp"
   depends_on "freeimage"
@@ -20,7 +21,6 @@ class Allolib < Formula
     end
 
     lib.install Dir["al/lib/libal.a"]
-    lib.install Dir["al/lib/libGamma.a"]
     include.install Dir["al/include/al"]
 
     test do
@@ -29,7 +29,6 @@ class Allolib < Formula
 
   def uninstall
     lib.uninstall Dir["al/lib/libal.a"]
-    lib.uninstall Dir["al/lib/libGamma.a"]
     include.uninstall Dir["al/include/al"]
   end
 end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -4,6 +4,7 @@ class Allolib < Formula
   head "https://github.com/akshay1992/allolib.git"
 
   depends_on "cmake" => :build
+  depends_on "Gamma"
   depends_on "assimp"
   depends_on "freeimage"
   depends_on "freetype"

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -19,7 +19,7 @@ class Allolib < Formula
   def install
     mkdir "build" do
       system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
-      system "make", "al", "-j16"
+      system "make", "al"
       system "make", "install"
     end
 

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,21 +1,24 @@
-require 'formula'
-
 class Allolib < Formula
-  head 'https://github.com/akshay1992/allolib', :revision => "afa8e92203cda2c110d724b401cdfd9b6387204e"
+  desc "AlloSystem for OpenGL 3.3 or higher"
+  homepage "https://github.com/AlloSphere-Research-Group/allolib"
+  head "https://github.com/akshay1992/allolib", :revision => "afa8e92203cda2c110d724b401cdfd9b6387204e"
 
-  depends_on 'cmake' => :build
-  depends_on 'assimp'
-  depends_on 'freeimage'
-  depends_on 'freetype'
-  depends_on 'glfw3'
-  depends_on 'portaudio'
-  depends_on 'libsndfile'
+  depends_on "cmake" => :build
+  depends_on "assimp"
+  depends_on "freeimage"
+  depends_on "freetype"
+  depends_on "glfw"
+  depends_on "libsndfile"
+  depends_on "portaudio"
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
-      system "make al"
-      system "make install"
-   end
+    system "cmake", ".", "-DNO_EXAMPLES=1", *std_cmake_args
+    system "make", "al"
+    system "make", "install"
+    end
+
+    test do
+    end
   end
 end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -13,12 +13,22 @@ class Allolib < Formula
 
   def install
     mkdir "build" do
-    system "cmake", "..", "-DNO_EXAMPLES=1", "-DCMAKE_INSTALL_PREFIX=#{prefix}", *std_cmake_args
-    system "make", "al"
-    system "make", "install"
+      system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
+      system "make", "al"
+      system "make", "install"
     end
+
+    lib.install Dir["al/lib/libal.a"]
+    lib.install Dir["al/lib/libGamma.a"]
+    include.install Dir["al/include/al"]
 
     test do
     end
+  end
+
+  def uninstall
+    lib.uninstall Dir["al/lib/libal.a"]
+    lib.uninstall Dir["al/lib/libGamma.a"]
+    include.uninstall Dir["al/include/al"]
   end
 end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -13,7 +13,7 @@ class Allolib < Formula
 
   def install
     mkdir "build" do
-    system "cmake", ".", "-DNO_EXAMPLES=1", *std_cmake_args
+    system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
     system "make", "al"
     system "make", "install"
     end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,6 +1,6 @@
 require 'formula'
 
-class allolib < Formula
+class Allolib < Formula
   head 'https://github.com/AlloSphere-Research-Group/allolib', :branch => "devel"
 
   depends_on 'cmake' => :build
@@ -12,8 +12,12 @@ class allolib < Formula
   depends_on 'libsndfile'
 
   def install
-    system "cmake", ".", "-DNO_EXAMPLES=1", *std_cmake_args
-    system "make"
-    system "make install"
+    system "git submodule init"
+    system "git submodule update"
+    mkdir "build" do
+      system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
+      system "make al"
+      system "make install"
+   end
   end
 end

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Allolib < Formula
-  url 'https://github.com/akshay1992/allolib'
+  head 'https://github.com/akshay1992/allolib', :revision => "afa8e92203cda2c110d724b401cdfd9b6387204e"
 
   depends_on 'cmake' => :build
   depends_on 'assimp'

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,7 +1,7 @@
 require 'formula'
 
 class Allolib < Formula
-  head 'https://github.com/akshay1992/allolib', :branch => "devel"
+  head 'https://github.com/akshay1992/allolib', :revision => "afa8e92203cda2c110d724b401cdfd9b6387204e"
 
   depends_on 'cmake' => :build
   depends_on 'assimp'

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -14,6 +14,7 @@ class Allolib < Formula
   depends_on "rt-audio"
   depends_on "rtmidi"
   depends_on "portaudio"
+  depends_on "fftw3"
 
   def install
     mkdir "build" do

--- a/Formula/allolib.rb
+++ b/Formula/allolib.rb
@@ -1,7 +1,7 @@
 class Allolib < Formula
   desc "AlloSystem for OpenGL 3.3 or higher"
   homepage "https://github.com/AlloSphere-Research-Group/allolib"
-  head "https://github.com/AlloSphere-Research-Group/allolib.git"
+  head "https://github.com/akshay1992/allolib.git"
 
   depends_on "cmake" => :build
   depends_on "apr"
@@ -11,12 +11,14 @@ class Allolib < Formula
   depends_on "freetype"
   depends_on "glfw"
   depends_on "libsndfile"
+  depends_on "rt-audio"
+  depends_on "rtmidi"
   depends_on "portaudio"
 
   def install
     mkdir "build" do
       system "cmake", "..", "-DNO_EXAMPLES=1", *std_cmake_args
-      system "make", "al"
+      system "make", "al", "-j16"
       system "make", "install"
     end
 


### PR DESCRIPTION
Updated the formula to be able to successfully build allolib (and Gamma) from the formula. 

Changes (in a nutshell): 
* Successfully builds allolib and Gamma while running `brew install`
* Adds a `Gamma.rb` to build and install Gamma separately
* Points allolib to the Gamma dependency. 
* Added the dependencies from allosystem's readme. I'm not sure if allolib has the same list of dependencies as allosystem. 

Caveats: 
* This required fixing a seemingly ignored `NO_EXAMPLES` flag in the root CMakeLists.txt in allolib ([pull-request](https://github.com/AlloSphere-Research-Group/allolib/pull/21)). Currently `allolib.rb` points to my fork until that pull request gets merged.
* Not thoroughly tested. Given that I'm not intimately familiar with the build process, I am hoping others can poke at it and verify that the build configurations look correct. 